### PR TITLE
Catch dependency errors building in isolation

### DIFF
--- a/ecl_errors/src/lib/CMakeLists.txt
+++ b/ecl_errors/src/lib/CMakeLists.txt
@@ -14,6 +14,13 @@ target_link_libraries(${PROJECT_NAME}
   PUBLIC ecl_config::ecl_config
 )
 
+target_include_directories(
+  ${PROJECT_NAME}
+  INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
 set_target_properties(${PROJECT_NAME}
   PROPERTIES
     SOVERSION ${${PROJECT_NAME}_VERSION}


### PR DESCRIPTION
Hadn't done this previously so a few errors were hiding.