### PR TITLE
Make sure to ament_export_libraries.

### DIFF
--- a/ecl_errors/CMakeLists.txt
+++ b/ecl_errors/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(ecl_config REQUIRED)
 # Project Configuration
 ##############################################################################
 
+ament_package_xml()
 ecl_enable_cxx14_compiler()
 
 ##############################################################################
@@ -32,4 +33,5 @@ add_subdirectory(src)
 
 ament_export_interfaces(${PROJECT_NAME})
 ament_export_dependencies(ecl_config)
+ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_io/CMakeLists.txt
+++ b/ecl_io/CMakeLists.txt
@@ -31,6 +31,7 @@ find_package(ecl_errors REQUIRED)
 # Project Configuration
 ##############################################################################
 
+ament_package_xml()
 ecl_enable_cxx14_compiler()
 
 include_directories(include
@@ -54,4 +55,5 @@ ament_export_dependencies(
     ecl_config
     ecl_errors
 )
+ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_time_lite/CMakeLists.txt
+++ b/ecl_time_lite/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(ecl_errors REQUIRED)
 # Project Configuration
 ##############################################################################
 
+ament_package_xml()
 ecl_enable_cxx14_compiler()
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include)
@@ -43,4 +44,5 @@ ament_export_dependencies(
     ecl_config
     ecl_errors
 )
+ament_export_libraries(${PROJECT_NAME})
 ament_package()


### PR DESCRIPTION
ament_export_libraries() ends up generating a setup.sh file
for each library that exports LD_LIBRARY_PATH.  This is
important when building in isolated mode so that downstream
consumers of the libraries can find the library at runtime.
This commit also adds 'ament_package_xml()' where appropriate
to ensure that the version numbers get set.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>