### PR TITLE
[infra] library exports

### DIFF
--- a/ecl_errors/CMakeLists.txt
+++ b/ecl_errors/CMakeLists.txt
@@ -32,4 +32,5 @@ add_subdirectory(src)
 
 ament_export_interfaces(${PROJECT_NAME})
 ament_export_dependencies(ecl_config)
+ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_io/.settings/language.settings.xml
+++ b/ecl_io/.settings/language.settings.xml
@@ -4,8 +4,11 @@
 		<extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
-			<provider-reference id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" ref="shared-provider"/>
-			<provider-reference id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" ref="shared-provider"/>
+			<provider copy-of="extension" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser"/>
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-993328506727902806" id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+				<language-scope id="org.eclipse.cdt.core.gcc"/>
+				<language-scope id="org.eclipse.cdt.core.g++"/>
+			</provider>
 			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
 		</extension>
 	</configuration>

--- a/ecl_io/CMakeLists.txt
+++ b/ecl_io/CMakeLists.txt
@@ -54,4 +54,5 @@ ament_export_dependencies(
     ecl_config
     ecl_errors
 )
+ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_time_lite/CMakeLists.txt
+++ b/ecl_time_lite/CMakeLists.txt
@@ -43,4 +43,5 @@ ament_export_dependencies(
     ecl_config
     ecl_errors
 )
+ament_export_libraries(${PROJECT_NAME})
 ament_package()


### PR DESCRIPTION
So that setup.sh gets created in isolated builds. Questionable as to
whether we should have to do both interfaces AND libraries.