### PR TITLE
Fix warnings

### DIFF
--- a/ecl_config/src/test/endianness.cpp
+++ b/ecl_config/src/test/endianness.cpp
@@ -23,6 +23,7 @@
  */
 TEST(TypeTests,fundamentals) {
 	bool result = ecl::is_big_endian();
+        (void)result;
 	result = false;
     SUCCEED();
 }

--- a/ecl_config/src/test/portable_types.cpp
+++ b/ecl_config/src/test/portable_types.cpp
@@ -22,20 +22,20 @@
  * compile time if they aren't.
  */
 TEST(TypeTests,fundamentals) {
-	ecl::int8 i8 = 1; i8 = 2;
-	ecl::uint8 ui8 = 1; ui8 = 2;
-	ecl::int8 i16 = 1; i16 = 2;
-	ecl::uint8 ui16 = 1; ui16 = 2;
-	ecl::int8 i32 = 1; i32 = 2;
-	ecl::uint8 ui32 = 1; ui32 = 2;
-	ecl::int8 i64 = 1; i64 = 1;
-	ecl::uint8 ui64 = 1; ui64 = 2;
-	ecl::float32 f32 = 1.0; f32 = 2.0;
-	ecl::float64 f64 = 1.0; f64 = 2.0;
+	ecl::int8 i8 = 1; i8 = 2; (void)i8;
+	ecl::uint8 ui8 = 1; ui8 = 2; (void)ui8;
+	ecl::int8 i16 = 1; i16 = 2; (void)i16;
+	ecl::uint8 ui16 = 1; ui16 = 2; (void)ui16;
+	ecl::int8 i32 = 1; i32 = 2; (void)i32;
+	ecl::uint8 ui32 = 1; ui32 = 2; (void)ui32;
+	ecl::int8 i64 = 1; i64 = 1; (void)i64;
+	ecl::uint8 ui64 = 1; ui64 = 2; (void)ui64;
+	ecl::float32 f32 = 1.0; f32 = 2.0; (void)f32;
+	ecl::float64 f64 = 1.0; f64 = 2.0; (void)f64;
 	#if ECL_SIZE_OF_LONG_DOUBLE == 12
-		ecl::float96 f96 = 1.0; f96 = 2.0;
+		ecl::float96 f96 = 1.0; f96 = 2.0; (void)f96;
 	#elif ECL_SIZE_OF_LONG_DOUBLE == 16
-		ecl::float128 f128 = 1.0; f128 = 2.0;
+		ecl::float128 f128 = 1.0; f128 = 2.0; (void)f128;
 	#endif
     SUCCEED();
 }

--- a/ecl_converters_lite/src/test/byte_array.cpp
+++ b/ecl_converters_lite/src/test/byte_array.cpp
@@ -30,7 +30,7 @@ TEST(ConverterTests, byteArrays) {
 	unsigned char u_three_six_three[4] = { 0x6b, 0x01, 0x00, 0x00 };
 	// generates narrow conversion errors if lots of warnings are on
 	// char minus_two[4] = { 0xfe, 0xff, 0xff, 0xff };
-	char minus_two[4] = { -2, -1, -1, -1 };
+	signed char minus_two[4] = { -2, -1, -1, -1 };
 	signed char s_minus_two[4] = { -2, -1, -1, -1 };
 	unsigned char u_minus_two[4] = { 0xfe, 0xff, 0xff, 0xff };
 	ecl::from_byte_array(value, three_six_three);

--- a/ecl_errors/src/examples/CMakeLists.txt
+++ b/ecl_errors/src/examples/CMakeLists.txt
@@ -9,6 +9,7 @@ macro(ecl_errors_add_example name)
     ${PROJECT_NAME}
   )
   set_target_properties(${target_name} PROPERTIES OUTPUT_NAME demo_${name})
+  set_target_properties(${target_name} PROPERTIES COMPILE_FLAGS "-Wno-unused-local-typedefs")
   install(TARGETS ${target_name} RUNTIME DESTINATION lib/${PROJECT_NAME})
 endmacro()
 

--- a/ecl_io/.settings/language.settings.xml
+++ b/ecl_io/.settings/language.settings.xml
@@ -1,15 +1,28 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project>
-	<configuration id="cdt.managedbuild.toolchain.gnu.base.943365629" name="Default">
-		<extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
-			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
-			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
-			<provider copy-of="extension" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser"/>
-			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="-993328506727902806" id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
-				<language-scope id="org.eclipse.cdt.core.gcc"/>
-				<language-scope id="org.eclipse.cdt.core.g++"/>
-			</provider>
-			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
-		</extension>
-	</configuration>
+    	
+    <configuration id="cdt.managedbuild.toolchain.gnu.base.943365629" name="Default">
+        		
+        <extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
+            			
+            <provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
+            			
+            <provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
+            			
+            <provider copy-of="extension" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser"/>
+            			
+            <provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuiltinSpecsDetector" console="false" env-hash="777298391135677359" id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" keep-relative-paths="false" name="CDT GCC Built-in Compiler Settings" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+                				
+                <language-scope id="org.eclipse.cdt.core.gcc"/>
+                				
+                <language-scope id="org.eclipse.cdt.core.g++"/>
+                			
+            </provider>
+            			
+            <provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
+            		
+        </extension>
+        	
+    </configuration>
+    
 </project>

--- a/ecl_io/src/examples/poll.cpp
+++ b/ecl_io/src/examples/poll.cpp
@@ -58,6 +58,9 @@ void sleep_one_sec() {
 
 int main(int argc, char **argv) {
 
+	(void)argc;
+	(void)argv;
+
 	ecl::SocketError error = ecl::init_sockets();
 	if ( error.flag() != ecl::NoError ) {
 		std::cout << error.what() << std::endl;

--- a/ecl_io/src/examples/poll.cpp
+++ b/ecl_io/src/examples/poll.cpp
@@ -56,10 +56,7 @@ void sleep_one_sec() {
 ** Main
 *****************************************************************************/
 
-int main(int argc, char **argv) {
-
-	(void)argc;
-	(void)argv;
+int main(int /*argc*/, char** /*argv*/) {
 
 	ecl::SocketError error = ecl::init_sockets();
 	if ( error.flag() != ecl::NoError ) {

--- a/ecl_io/src/examples/socketpair.cpp
+++ b/ecl_io/src/examples/socketpair.cpp
@@ -68,6 +68,9 @@ int socket_error() {
 
 int main(int argc, char **argv) {
 
+	(void)argc;
+	(void)argv;
+
 	ecl::SocketError error = ecl::init_sockets();
 	if ( error.flag() != ecl::NoError ) {
 		std::cout << error.what() << std::endl;

--- a/ecl_io/src/examples/socketpair.cpp
+++ b/ecl_io/src/examples/socketpair.cpp
@@ -66,10 +66,7 @@ int socket_error() {
 ** Main
 *****************************************************************************/
 
-int main(int argc, char **argv) {
-
-	(void)argc;
-	(void)argv;
+int main(int /*argc*/, char** /*argv*/) {
 
 	ecl::SocketError error = ecl::init_sockets();
 	if ( error.flag() != ecl::NoError ) {

--- a/ecl_io/src/examples/sockets.cpp
+++ b/ecl_io/src/examples/sockets.cpp
@@ -21,10 +21,7 @@
 ** Main program
 *****************************************************************************/
 
-int main(int argc, char **argv) {
-
-    (void)argc;
-    (void)argv;
+int main(int /*argc*/, char** /*argv*/) {
 
     ecl::SocketError error = ecl::init_sockets();
     if ( error.flag() != ecl::NoError ) {

--- a/ecl_io/src/examples/sockets.cpp
+++ b/ecl_io/src/examples/sockets.cpp
@@ -23,6 +23,9 @@
 
 int main(int argc, char **argv) {
 
+    (void)argc;
+    (void)argv;
+
     ecl::SocketError error = ecl::init_sockets();
     if ( error.flag() != ecl::NoError ) {
     	std::cout << error.what() << std::endl;

--- a/ecl_sigslots_lite/src/examples/sigslots.cpp
+++ b/ecl_sigslots_lite/src/examples/sigslots.cpp
@@ -67,6 +67,9 @@ const unsigned int ecl::lite::GlobalSlots<void>::capacity = 2;
 
 int main(int argc, char **argv) {
 
+    (void)argc;
+    (void)argv;
+
 	Foo foo;
 
     std::cout << std::endl;

--- a/ecl_sigslots_lite/src/examples/sigslots.cpp
+++ b/ecl_sigslots_lite/src/examples/sigslots.cpp
@@ -65,12 +65,9 @@ const unsigned int ecl::lite::GlobalSlots<void>::capacity = 2;
 ** Main
 *****************************************************************************/
 
-int main(int argc, char **argv) {
+int main(int /*argc*/, char** /*argv*/) {
 
-    (void)argc;
-    (void)argv;
-
-	Foo foo;
+    Foo foo;
 
     std::cout << std::endl;
     std::cout << "***********************************************************" << std::endl;


### PR DESCRIPTION
This PR fixes a slew of warnings that I see when compiling ecl_lite on Ubuntu 18.04, both on amd64 and on arm64. After these patches (and the equivalent ones on ecl_core), I have a clean build of sophus, ecl_core, and ecl_lite.