### PR TITLE
[infra] revert workaround for exporting interfaces with libraries

### DIFF
--- a/ecl_errors/CMakeLists.txt
+++ b/ecl_errors/CMakeLists.txt
@@ -31,7 +31,6 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
-ament_export_interfaces(${PROJECT_NAME})
+ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(ecl_config)
-ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_io/CMakeLists.txt
+++ b/ecl_io/CMakeLists.txt
@@ -50,10 +50,9 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
-ament_export_interfaces(${PROJECT_NAME})
+ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config
     ecl_errors
 )
-ament_export_libraries(${PROJECT_NAME})
 ament_package()

--- a/ecl_time_lite/CMakeLists.txt
+++ b/ecl_time_lite/CMakeLists.txt
@@ -39,10 +39,9 @@ add_subdirectory(src)
 ##############################################################################
 
 ament_export_include_directories(include)
-ament_export_interfaces(${PROJECT_NAME})
+ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(
     ecl_config
     ecl_errors
 )
-ament_export_libraries(${PROJECT_NAME})
 ament_package()


### PR DESCRIPTION
As brought in, in PR 73

   https://github.com/stonier/ecl_core/pull/73

Reported in

    https://github.com/ament/ament_cmake/issues/132

And fixed in

    https://github.com/ament/ament_cmake/pull/135/files