### PR TITLE
export include directories

### DIFF
--- a/ecl_config/CMakeLists.txt
+++ b/ecl_config/CMakeLists.txt
@@ -53,6 +53,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
+ament_export_include_directories(include)
 ament_export_interfaces(${PROJECT_NAME})
 ament_package()
 

--- a/ecl_errors/CMakeLists.txt
+++ b/ecl_errors/CMakeLists.txt
@@ -31,6 +31,7 @@ add_subdirectory(src)
 # Exports
 ##############################################################################
 
+ament_export_include_directories(include)
 ament_export_interfaces(HAS_LIBRARY_TARGET ${PROJECT_NAME})
 ament_export_dependencies(ecl_config)
 ament_package()


### PR DESCRIPTION
in order to get the turtlebot2_demo in ROS2 to run correctly, the ecl include directories have to be exported explicitly. 