### PR TITLE
enable kobuki Windows build

### DIFF
--- a/ecl_config/include/ecl/config.hpp
+++ b/ecl_config/include/ecl/config.hpp
@@ -30,9 +30,7 @@
  * Includes
  ****************************************************************************/
 
-#if defined(ECL_IS_WIN32)
-    // #include "config/windows.hpp"
-#elif defined(ECL_IS_POSIX)
+#if defined(ECL_IS_POSIX)
     #include <unistd.h>
 #endif
 

--- a/ecl_config/include/ecl/config.hpp
+++ b/ecl_config/include/ecl/config.hpp
@@ -31,7 +31,7 @@
  ****************************************************************************/
 
 #if defined(ECL_IS_WIN32)
-	#include "config/windows.hpp"
+    // #include "config/windows.hpp"
 #elif defined(ECL_IS_POSIX)
     #include <unistd.h>
 #endif

--- a/ecl_config/include/ecl/config/windows.hpp
+++ b/ecl_config/include/ecl/config/windows.hpp
@@ -29,10 +29,10 @@
   #endif
 
   #ifdef _MSC_VER
-    #pragma warning(disable: 4251)  // Disable warnings about import/exports when deriving from std classes
-    #pragma warning(disable: 4275)  // ""
-    #pragma warning (disable:4996)  // Disable warnings about deprecated ctime
-    #pragma warning (disable:4290)  // Disable warnings about unsupported c++ exception specifications
+    #pragma warning(disable:4251)  // Disable warnings about import/exports when deriving from std classes
+    #pragma warning(disable:4275)  // ""
+    #pragma warning(disable:4996)  // Disable warnings about deprecated ctime
+    #pragma warning(disable:4290)  // Disable warnings about unsupported c++ exception specifications
   #endif
 #endif
 

--- a/ecl_config/include/ecl/config/windows.hpp
+++ b/ecl_config/include/ecl/config/windows.hpp
@@ -29,10 +29,10 @@
   #endif
 
   #ifdef _MSC_VER
-    #pragma warning(disable:4251)  // Disable warnings about import/exports when deriving from std classes
-    #pragma warning(disable:4275)  // ""
-    #pragma warning(disable:4996)  // Disable warnings about deprecated ctime
-    #pragma warning(disable:4290)  // Disable warnings about unsupported c++ exception specifications
+    #pragma warning(disable: 4251)  // Disable warnings about import/exports when deriving from std classes
+    #pragma warning(disable: 4275)  // ""
+    #pragma warning (disable:4996)  // Disable warnings about deprecated ctime
+    #pragma warning (disable:4290)  // Disable warnings about unsupported c++ exception specifications
   #endif
 #endif
 

--- a/ecl_time_lite/include/ecl/time_lite/date.hpp
+++ b/ecl_time_lite/include/ecl/time_lite/date.hpp
@@ -16,7 +16,7 @@
 
 #include <ecl/time_lite/config.hpp>
 
-#if defined(ECL_HAS_POSIX_TIMERS) || defined (ECL_HAS_RT_TIMERS) || defined(ECL_HAS_MACH_TIMERS)
+#if defined(ECL_HAS_POSIX_TIMERS) || defined (ECL_HAS_RT_TIMERS) || defined(ECL_HAS_MACH_TIMERS) || defined(ECL_HAS_WIN_TIMERS)
 
 /*****************************************************************************
 ** Includes

--- a/ecl_time_lite/src/lib/date.cpp
+++ b/ecl_time_lite/src/lib/date.cpp
@@ -11,7 +11,7 @@
 
 #include <ecl/time_lite/config.hpp>
 
-#if defined(ECL_HAS_POSIX_TIMERS) || defined(ECL_HAS_RT_TIMERS) || defined(ECL_HAS_MACH_TIMERS)
+#if defined(ECL_HAS_POSIX_TIMERS) || defined(ECL_HAS_RT_TIMERS) || defined(ECL_HAS_MACH_TIMERS) || defined(ECL_HAS_WIN_TIMERS)
 
 /*****************************************************************************
 ** Includes


### PR DESCRIPTION
this library needs to be updated in order to enable the kobuki code base to build on Windows
- to prevent macro pollution from `windows.h`, `windows.h` should not be included in header files

this port points to the melodic release branch because it currently only targets ROS1.melodic