### PR TITLE
[ecl_lite] fix clang induced pedantic warnings

### DIFF
--- a/ecl_config/package.xml
+++ b/ecl_config/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>ecl_config</name>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <description>
      These tools inspect and describe your system with macros, types
      and functions.

--- a/ecl_console/package.xml
+++ b/ecl_console/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>ecl_console</name>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <description>
      Color codes for ansii consoles.
   </description>

--- a/ecl_converters_lite/package.xml
+++ b/ecl_converters_lite/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>ecl_converters_lite</name>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <description>
      These are a very simple version of some of the functions in ecl_converters
      suitable for firmware development. That is, there is no use of new,

--- a/ecl_errors/CHANGELOG.rst
+++ b/ecl_errors/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 
 Forthcoming
 -----------
+* ...
+
+1.0.3 (2018-08-21)
+------------------
+* pedantic error message fixes for ecl_compile_time_assert on clang/macosx
 * explicit construction for the Error class so surprising things can't happen
 * equality operator for the Error class
 

--- a/ecl_errors/include/ecl/errors/compile_time_assert.hpp
+++ b/ecl_errors/include/ecl/errors/compile_time_assert.hpp
@@ -58,7 +58,7 @@ template <int x> struct static_assert_test {};
  * the unit testing facility.
  */
 #define ecl_compile_time_assert( logical_expression ) \
-   typedef ecl::static_assert_test<sizeof(ecl::COMPILE_TIME_FAILURE< static_cast<bool>(logical_expression) >)> JOIN(compile_time_check,__LINE__)
+   typedef ecl::static_assert_test<sizeof(ecl::COMPILE_TIME_FAILURE< static_cast<bool>(logical_expression) >)> JOIN(compile_time_check,__LINE__) __attribute__((unused))
 
 /**
  * @brief Verbose compile time assert.

--- a/ecl_errors/package.xml
+++ b/ecl_errors/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>ecl_errors</name>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <description>
     This library provides lean and mean error mechanisms.
     It includes c style error functions as well as a few

--- a/ecl_io/package.xml
+++ b/ecl_io/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>ecl_io</name>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <description>
      Most implementations (windows, posix, ...) have slightly different api for
      low level input-output functions. These are gathered here and re-represented

--- a/ecl_lite/package.xml
+++ b/ecl_lite/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>ecl_lite</name>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <description>
     Libraries and utilities for embedded and low-level linux development.
   </description>

--- a/ecl_sigslots_lite/package.xml
+++ b/ecl_sigslots_lite/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>ecl_sigslots_lite</name>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <description>
      This avoids use of dynamic storage (malloc/new) and thread safety (mutexes) to
      provide a very simple sigslots implementation that can be used for *very*

--- a/ecl_time_lite/CHANGELOG.rst
+++ b/ecl_time_lite/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+1.0.3 (2018-08-21)
+------------------
+* pedantic error message fixes for const error string methods on clang/macosx
+
 0.61.1 (2015-07-26)
 -------------------
 * support get_date_string on macosx.

--- a/ecl_time_lite/include/ecl/time_lite/errors.hpp
+++ b/ecl_time_lite/include/ecl/time_lite/errors.hpp
@@ -41,11 +41,11 @@ public:
   TimeError(const ErrorFlag& flag = UnknownError) : Error(flag) {}
 
 protected:
-  virtual const char* outOfRangeErrorString() { return "The input time sec/nsec pair was outside of the permitted range."; }
-  virtual const char* argNotSupportedErrorString() { return "The clock specified is not supported on this system."; }
-  virtual const char* permissionsErrorString() { return "You do not have permission to set the specified clock."; }
-  virtual const char* memoryErrorString() { return "One of the input arguments is not in memory addressable space."; }
-  virtual const char* interruptedErrorString() { return "This operation was interrupted by a signal."; }
+  virtual const char* outOfRangeErrorString() const { return "The input time sec/nsec pair was outside of the permitted range."; }
+  virtual const char* argNotSupportedErrorString() const { return "The clock specified is not supported on this system."; }
+  virtual const char* permissionsErrorString() const { return "You do not have permission to set the specified clock."; }
+  virtual const char* memoryErrorString() const { return "One of the input arguments is not in memory addressable space."; }
+  virtual const char* interruptedErrorString() const { return "This operation was interrupted by a signal."; }
 };
 
 } // namespace ecl

--- a/ecl_time_lite/package.xml
+++ b/ecl_time_lite/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>ecl_time_lite</name>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <description>
      Provides a portable set of time functions that are especially useful for
      porting other code or being wrapped by higher level c++ classes.


### PR DESCRIPTION
Cherry picks commits from #26 and bumps the version.