### PR TITLE
[Windows][ROS2] MSVC build break fixes.

### DIFF
--- a/ecl_errors/include/ecl/errors/compile_time_assert.hpp
+++ b/ecl_errors/include/ecl/errors/compile_time_assert.hpp
@@ -58,7 +58,7 @@ template <int x> struct static_assert_test {};
  * the unit testing facility.
  */
 #define ecl_compile_time_assert( logical_expression ) \
-   typedef ecl::static_assert_test<sizeof(ecl::COMPILE_TIME_FAILURE< static_cast<bool>(logical_expression) >)> JOIN(compile_time_check,__LINE__) __attribute__((unused))
+   typedef ecl::static_assert_test<sizeof(ecl::COMPILE_TIME_FAILURE< static_cast<bool>(logical_expression) >)> JOIN(compile_time_check,__LINE__) [[gnu::unused]]
 
 /**
  * @brief Verbose compile time assert.

--- a/ecl_errors/src/examples/CMakeLists.txt
+++ b/ecl_errors/src/examples/CMakeLists.txt
@@ -9,7 +9,9 @@ macro(ecl_errors_add_example name)
     ${PROJECT_NAME}
   )
   set_target_properties(${target_name} PROPERTIES OUTPUT_NAME demo_${name})
-  set_target_properties(${target_name} PROPERTIES COMPILE_FLAGS "-Wno-unused-local-typedefs")
+  if(CMAKE_COMPILER_IS_GNUCXX)
+    set_target_properties(${target_name} PROPERTIES COMPILE_FLAGS "-Wno-unused-local-typedefs")
+  endif()
   install(TARGETS ${target_name} RUNTIME DESTINATION lib/${PROJECT_NAME})
 endmacro()
 


### PR DESCRIPTION
* Replaced `__attribute__((unused))` with modern C++ expression: `[[gnu::unused]]`
* Conditionally include `-Wno-unused-local-typedefs` only when the compiler is `GNU C++`.