### PR TITLE
[sigslots_lite] new c++14 insists on const expr init in the same translation unit

### DIFF
--- a/ecl_config/package.xml
+++ b/ecl_config/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>ecl_config</name>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
   <description>
      These tools inspect and describe your system with macros, types
      and functions.

--- a/ecl_console/package.xml
+++ b/ecl_console/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>ecl_console</name>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
   <description>
      Color codes for ansii consoles.
   </description>

--- a/ecl_converters_lite/package.xml
+++ b/ecl_converters_lite/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>ecl_converters_lite</name>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
   <description>
      These are a very simple version of some of the functions in ecl_converters
      suitable for firmware development. That is, there is no use of new,

--- a/ecl_errors/package.xml
+++ b/ecl_errors/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>ecl_errors</name>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
   <description>
     This library provides lean and mean error mechanisms.
     It includes c style error functions as well as a few

--- a/ecl_io/package.xml
+++ b/ecl_io/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>ecl_io</name>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
   <description>
      Most implementations (windows, posix, ...) have slightly different api for
      low level input-output functions. These are gathered here and re-represented

--- a/ecl_lite/package.xml
+++ b/ecl_lite/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>ecl_lite</name>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
   <description>
     Libraries and utilities for embedded and low-level linux development.
   </description>

--- a/ecl_sigslots_lite/CHANGELOG.rst
+++ b/ecl_sigslots_lite/CHANGELOG.rst
@@ -1,4 +1,14 @@
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Changelog for package ecl_sigslots_lite
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Release Notes
+=============
 
+Forthcoming
+-----------
+
+1.2.0 (2022-09-27)
+------------------
+* [sigslots_lite] new c++14 insists on const expr init in the same translation unit, `#38 <https://github.com/stonier/ecl_lite/pull/38>`_
+
+Pre-Versioning
+--------------
+* (2011-03-11) redeisnged to be more self contained
+* (2011-02-11) prototype implementation tested

--- a/ecl_sigslots_lite/include/ecl/sigslots_lite/connect.hpp
+++ b/ecl_sigslots_lite/include/ecl/sigslots_lite/connect.hpp
@@ -112,9 +112,10 @@ sigslots::Error connect(Signal<Data,Capacity> &signal, void(FunctionClass::*f)(D
  * @param function : the global/static function to slot.
  * @return Error : the sigslots error
  */
-template <typename Data, unsigned int Capacity>
-sigslots::Error connect(Signal<Data, Capacity> &signal, void (*function)(Data)) {
-	sigslots::GlobalSlot<Data> *slot = GlobalSlots<Data>::addSlot(function);
+template <typename Data, unsigned int Capacity, typename GlobalClass>
+sigslots::Error connect(Signal<Data, Capacity> &signal, void (*function)(Data), GlobalClass &g) {
+	sigslots::GlobalSlotsBase<Data,GlobalClass> &global_slots = g;
+	sigslots::GlobalSlot<Data> *slot = global_slots.addSlot(function);
 	if ( slot != NULL ) {
 		return sigslots::connect(signal,*slot);
 	} else {
@@ -159,9 +160,10 @@ sigslots::Error connect(Signal<void, Capacity> &signal, void(FunctionClass::*fun
  * @param function : the global/static function to slot.
  * @return Error : the sigslots error
  */
-template <unsigned int Capacity>
-sigslots::Error connect(Signal<void, Capacity> &signal, void (*function)(void)) {
-	sigslots::GlobalSlot<void> *slot = GlobalSlots<void>::addSlot(function);
+template <unsigned int Capacity, typename GlobalClass>
+sigslots::Error connect(Signal<void, Capacity> &signal, void (*function)(void), GlobalClass &g) {
+	sigslots::GlobalSlotsBase<void,GlobalClass> &global_slots = g;
+	sigslots::GlobalSlot<void> *slot = global_slots.addSlot(function);
 	if ( slot != NULL ) {
 		return sigslots::connect(signal,*slot);
 	} else {

--- a/ecl_sigslots_lite/include/ecl/sigslots_lite/managers.hpp
+++ b/ecl_sigslots_lite/include/ecl/sigslots_lite/managers.hpp
@@ -16,6 +16,8 @@
 ** Includes
 *****************************************************************************/
 
+#include <array>
+
 #include "slot.hpp"
 
 /*****************************************************************************
@@ -56,6 +58,22 @@ public:
 	virtual unsigned int stored() const { return 0; }
 	virtual unsigned int capacity() const { return 0; }
 	virtual sigslots::MemberSlot<void,FunctionClass>* addSlot(void (FunctionClass::*func)(), FunctionClass &instance) = 0;
+};
+
+template <typename Data, typename GlobalClass>
+class GlobalSlotsBase {
+public:
+	virtual unsigned int stored() const { return 0; }
+	virtual unsigned int capacity() const { return 0; }
+	virtual sigslots::GlobalSlot<Data>* addSlot( void (*function)(Data) ) = 0;
+};
+
+template <typename GlobalClass>
+class GlobalSlotsBase<void, GlobalClass> {
+public:
+	virtual unsigned int stored() const { return 0; }
+	virtual unsigned int capacity() const { return 0; }
+	virtual sigslots::GlobalSlot<void>* addSlot( void (*function)() ) = 0;
 };
 
 } // namespace sigslots
@@ -155,96 +173,67 @@ private:
 ** Global Manager
 *******************************************/
 
-/**
- * @brief This is the global slot interface.
- *
- * You'll need to preconfigure the capacity for this slot
- * interface. Note that the capacity corresponds to the
- * number of global functions with the specified footprint
- * (Data arg), not the total number of slottable global
- * functions overall.
- *
- * @code
- * // reserve the number of global slots that you'll use.
- * template<>
- * const unsigned int ecl::lite::GlobalSlots<const char*>::capacity = 2;
- *
- * void f(const char* str) {
- *     std::cout << "f() " << str << std::endl;
- * }
- *
- * void g(const char* str) {
- * 	   std::cout << "g() " << str << std::endl;
- * }
- *
- * int main() {
- *     ecl::lite::Signal<const char*,2> signal;
- *     connect(signal,f);
- *     connect(signal,g);
- *     signal.emit("Dude");
- * @endcode
- *
- * @tparam Data : the footprint for the type of global functions to slot.
- * @tparam Dummy : dummy argument to enable capacity to be a const expr for array bounds
- */
-template <typename Data, typename Dummy = int>
-class GlobalSlots {
+template <typename Data, typename GlobalClass, unsigned int Capacity = 1>
+class GlobalSlots : public sigslots::GlobalSlotsBase<Data, GlobalClass> {
 public:
-	static const unsigned int capacity;/**< @brief Number of global functions of this type that can be slotted. **/
-
 	/*********************
 	** Friends
 	**********************/
-	// needs access to addSlot()
-	template <typename Data_, unsigned int Capacity_>
-	friend sigslots::Error connect(Signal<Data_, Capacity_> &signal, void (*function)(Data_));
+	// allow connect to use addSlot
+	template <typename Data_, unsigned int Capacity_, typename GlobalClass_>
+	friend sigslots::Error connect(Signal<Data_,Capacity_> &signal, void(*function)(Data_), GlobalClass_ &g);
 
 	// needs access to stored()
-	template <typename Data_>
+	template <typename Data_, typename GlobalClass_>
 	friend unsigned int global_slots_stored();
+
+	// needs access to capacity()
+	template <typename Data_, typename GlobalClass_>
+	friend unsigned int global_slots_capacity();
+
+protected:
+	GlobalSlots() : size(0) {};
 
 private:
 	/**
-	 * @brief Number of slots currently stored.
+	 * @brief The number of slots stored.
 	 *
-	 * This is used for two purposes, 1) for recall and 2) to increment
-	 * since it holds a static variable internally. This is triggered
-	 * by the boolean argument which has a default value that can be hidden
-	 * when doing 1).
-	 *
-	 * @param increment : increment the storage value (called from addSlot)
-	 * @return : number of slots currently stored.
+	 * @return unsigned int : storage size.
 	 */
-	static unsigned int stored(const bool increment = false) {
-		static unsigned int stored_slots = 0;
-		if ( increment ) { ++stored_slots; }
-		return stored_slots;
-	}
+	unsigned int stored() const { return size; }
+	/**
+	 * @brief The number of slots that can be attached to member functions.
+	 *
+	 * @return unsigned int : the maximum capacity.
+	 */
+	unsigned int capacity() const { return Capacity; }
+
 	/**
 	 * @brief Add a slot.
 	 *
 	 * This is used 'under the hood' by the connectors.
 	 *
 	 * @param func : the function to slot.
-	 * @return GlobalSlot* : a pointer to a global slot.
+	 * @param instance : the class instance associated with the function.
+	 * @return MemberSlot* : a pointer to a member slot.
 	 */
-	static sigslots::GlobalSlot<Data>* addSlot(void (*func)(Data)) {
-		unsigned int size = stored();
-		static sigslots::GlobalSlot<Data> slots[capacity];
+	sigslots::GlobalSlot<Data>* addSlot(void (*function)(Data)) {
 		for ( unsigned int i = 0; i < size; ++i ) {
-			if ( func == slots[i].global_function ) {
+			if ( function == slots[i].global_function ) {
 				return &(slots[i]);
 			}
 		}
-		if ( size < capacity ) {
-			slots[size] = sigslots::GlobalSlot<Data>(func);
-			bool inc = true;
-			stored(inc); // increment the number of stored slots variable
-			return &(slots[size]);
+		if ( size < Capacity ) {
+			slots[size] = sigslots::GlobalSlot<Data>(function);
+			++size;
+			return &(slots[size-1]);
 		} else {
 			return NULL;
 		}
 	}
+
+	unsigned int size;
+	sigslots::GlobalSlot<Data> slots[Capacity];
 };
 
 /*****************************************************************************
@@ -316,44 +305,40 @@ private:
 	sigslots::MemberSlot<void,FunctionClass> slots[Capacity];
 };
 
-/**
- * @brief Specialisation for void global slots management.
- *
- * @tparam Dummy : dummy argument to enable capacity to be a const expr for array bounds
- */
-template <typename Dummy>
-class GlobalSlots<void, Dummy> {
+template <typename GlobalClass, unsigned int Capacity>
+class GlobalSlots<void, GlobalClass, Capacity> : public sigslots::GlobalSlotsBase<void, GlobalClass> {
 public:
-	static const unsigned int capacity; /**< @brief Number of global void functions that can be slotted. **/
-
-
 	/*********************
 	** Friends
 	**********************/
-	// needs access to addSlot()
-	template <unsigned int Capacity_>
-	friend sigslots::Error connect(Signal<void,Capacity_> &signal, void (*function)(void));
+	// allow connect to use addSlot
+	template <unsigned int Capacity_, typename GlobalClass_>
+	friend sigslots::Error connect(Signal<void,Capacity_> &signal, void(*function)(void), GlobalClass_ &g);
 
 	// needs access to stored()
-	template <typename Data> friend unsigned int global_slots_stored();
+	template <typename Data_, typename GlobalClass_>
+	friend unsigned int global_slots_stored();
+
+	// needs access to capacity()
+	template <typename Data_, typename GlobalClass_>
+	friend unsigned int global_slots_capacity();
+
+protected:
+	GlobalSlots() : size(0) {};
 
 private:
 	/**
-	 * @brief Number of slots currently stored.
+	 * @brief The number of slots stored.
 	 *
-	 * This is used for two purposes, 1) for recall and 2) to increment
-	 * since it holds a static variable internally. This is triggered
-	 * by the boolean argument which has a default value that can be hidden
-	 * when doing 1).
-	 *
-	 * @param increment : increment the storage value (called from addSlot)
-	 * @return : number of slots currently stored.
+	 * @return unsigned int : storage size.
 	 */
-	static unsigned int stored(const bool increment = false) {
-		static unsigned int stored_slots = 0;
-		if ( increment ) { ++stored_slots; }
-		return stored_slots;
-	}
+	unsigned int stored() const { return size; }
+	/**
+	 * @brief The number of slots that can be attached to member functions.
+	 *
+	 * @return unsigned int : the maximum capacity.
+	 */
+	unsigned int capacity() const { return Capacity; }
 
 	/**
 	 * @brief Add a slot.
@@ -361,26 +346,55 @@ private:
 	 * This is used 'under the hood' by the connectors.
 	 *
 	 * @param func : the function to slot.
-	 * @return GlobalSlot* : a pointer to a global slot.
+	 * @param instance : the class instance associated with the function.
+	 * @return GlobalSlot* : a pointer to a member slot.
 	 */
-	static sigslots::GlobalSlot<void>* addSlot(void (*func)(void)) {
-		unsigned int size = stored();
-		static sigslots::GlobalSlot<void> slots[capacity];
+	sigslots::GlobalSlot<void>* addSlot(void (*function)()) {
 		for ( unsigned int i = 0; i < size; ++i ) {
-			if ( func == slots[i].global_function ) {
+			if ( function == slots[i].global_function ) {
 				return &(slots[i]);
 			}
 		}
-		if ( size < capacity ) {
-			slots[size] = sigslots::GlobalSlot<void>(func);
-			bool inc = true;
-			stored(inc); // increment the number of stored slots variable
-			return &(slots[size]);
+		if ( size < Capacity ) {
+			slots[size] = sigslots::GlobalSlot<void>(function);
+			++size;
+			return &(slots[size-1]);
 		} else {
 			return NULL;
 		}
 	}
+
+	unsigned int size;
+	sigslots::GlobalSlot<void> slots[Capacity];
 };
+
+
+class Joe {
+public:
+    static inline void addSlot() {
+        // static std::array<float, GlobalSlots<void>::capacity> dods;
+        static std::array<float, 5> dods;
+        dods[0] = 3.0;
+        // std::cout << "Capacity: " << GlobalSlots<void>::capacity << std::endl;
+        std::cout << dods[0] << std::endl;
+    }
+};
+
+
+//template <typename Data, unsigned int Capacity>
+//struct GlobalManager : public GlobalSlots<Data, GlobalManager, Capacity> {};
+
+// template <typename Data, unsigned int Capacity = 1>
+// const GlobalManager<Data>& global_manager() {
+//     static GlobalManager<Data> god{};
+//     return god;
+// }
+
+//template <>
+//const GlobalManager<void>& global_manager() {
+//    static GlobalManager<void> god{};
+//    return god;
+//}
 
 
 } // namespace lite

--- a/ecl_sigslots_lite/include/ecl/sigslots_lite/utilities.hpp
+++ b/ecl_sigslots_lite/include/ecl/sigslots_lite/utilities.hpp
@@ -25,13 +25,16 @@
 namespace ecl {
 namespace lite {
 
-template <typename Data>
-unsigned int global_slots_stored() {
-	return GlobalSlots<Data>::stored();
+template <typename Data, typename GlobalClass>
+unsigned int global_slots_stored(const GlobalClass &object) {
+    const sigslots::GlobalSlotsBase<Data,GlobalClass> &global_slots = object;
+    return global_slots.stored();
 }
-template <typename Data>
-unsigned int global_slots_capacity() {
-	return GlobalSlots<Data>::capacity;
+
+template <typename Data, typename GlobalClass>
+unsigned int global_slots_capacity(const GlobalClass &object) {
+    const sigslots::GlobalSlotsBase<Data,GlobalClass> &global_slots = object;
+    return global_slots.capacity();
 }
 
 template <typename Data, typename FunctionClass>

--- a/ecl_sigslots_lite/mainpage.dox
+++ b/ecl_sigslots_lite/mainpage.dox
@@ -83,11 +83,15 @@
 	
 	@code
 	// allocate for global function slots with const char* and void arg footprints
-	template<> const unsigned int ecl::lite::GlobalSlots<const char*>::capacity = 4;
-	template<> const unsigned int ecl::lite::GlobalSlots<void>::capacity = 2;
-	
+	class GlobalManager : public ecl::lite::GlobalSlots<const char*,GlobalManager,3>,
+                      public ecl::lite::GlobalSlots<void,GlobalManager,1>
+    {
+    public:
+        GlobalManager() {};
+    };
 	int main() {
-	    // ...
+	    GlobalManager global_manager;
+        // ...
 	@endcode 
 
 	For member slots, your class needs to inherit from the MemberSlots interface and
@@ -120,8 +124,8 @@
 	pointers.
 	
 	@code
-	connect(signal,f);            // connecting to a global slot
-	connect(signal,&Foo::f, foo); // connecting to a member slot
+	connect(signal,f, global_manager);  // connecting to a global slot
+	connect(signal,&Foo::f, foo);       // connecting to a member slot
 	@endcode
 	
 	@subsection Utilities
@@ -130,12 +134,12 @@
 	
 	@code
 	// statistics for global slots with arg type 'const char*'
-	std::cout << ecl::lite::global_slots_stored<const char*>() << std::endl;
-	std::cout << ecl::lite::global_slots_capacity<const char*>() << std::endl;
+	std::cout << ecl::lite::global_slots_stored<const char*>(global_manager) << std::endl;
+	std::cout << ecl::lite::global_slots_capacity<const char*>(global_manager) << std::endl;
 
 	// statistics for global slots with no args
-	std::cout << ecl::lite::global_slots_stored<void>() << std::endl;
-	std::cout << ecl::lite::global_slots_capacity<void>() << std::endl;
+	std::cout << ecl::lite::global_slots_stored<void>(global_manager) << std::endl;
+	std::cout << ecl::lite::global_slots_capacity<void>(global_manager) << std::endl;
 
 	// statistics for member slots of foo with no args
 	std::cout << ecl::lite::member_slots_stored<void>(foo) << std::endl;
@@ -148,10 +152,4 @@
 	These are more of a rough coverage test.
 		
 	- src/examples/sigslots.cpp
-
-\section ChangeLog
-
-	- <b>Mar 11</b> : redesigned to be self contained.
-	- <b>Feb 11</b> : prototype implementation tested.
-
 */

--- a/ecl_sigslots_lite/package.xml
+++ b/ecl_sigslots_lite/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>ecl_sigslots_lite</name>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
   <description>
      This avoids use of dynamic storage (malloc/new) and thread safety (mutexes) to
      provide a very simple sigslots implementation that can be used for *very*

--- a/ecl_time_lite/package.xml
+++ b/ecl_time_lite/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>ecl_time_lite</name>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
   <description>
      Provides a portable set of time functions that are especially useful for
      porting other code or being wrapped by higher level c++ classes.


### PR DESCRIPTION
This fixes the errors:

```
23:07:06   233 |                 static sigslots::GlobalSlot<Data> slots[capacity];
23:07:06       |                                                   ^~~~~
23:07:06 /tmp/binarydeb/ros-rolling-ecl-sigslots-lite-1.1.0/src/examples/../../include/ecl/sigslots_lite/managers.hpp: In static member function ‘static ecl::lite::sigslots::GlobalSlot<void>* ecl::lite::GlobalSlots<void, Dummy>::addSlot(void (*)())’:
23:07:06 /tmp/binarydeb/ros-rolling-ecl-sigslots-lite-1.1.0/src/examples/../../include/ecl/sigslots_lite/managers.hpp:368:51: error: ISO C++ forbids variable length array ‘slots’ [-Werror=vla]
23:07:06   368 |                 static sigslots::GlobalSlot<void> slots[capacity];
```

Basically, c++14 with `-Wpedantic` insists on initialisation of const expr (for array bounds) in the same translation unit. This redesigns it so storage is more (to the tune of about 5 lines) in the hands of the user.