### PR TITLE
Replacing BSD with BSD-3-Clause in package.xml

### DIFF
--- a/ecl_config/package.xml
+++ b/ecl_config/package.xml
@@ -8,7 +8,7 @@
   </description>
   <author email="d.stonier@gmail.com">Daniel Stonier</author> -->
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_config</url>
   <url type="repository">https://github.com/stonier/ecl_lite</url>
   <url type="bugtracker">https://github.com/stonier/ecl_lite/issues</url>

--- a/ecl_console/package.xml
+++ b/ecl_console/package.xml
@@ -7,7 +7,7 @@
   </description>
   <author email="d.stonier@gmail.com">Daniel Stonier</author> -->
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_console</url>
   <url type="repository">https://github.com/stonier/ecl_lite</url>
   <url type="bugtracker">https://github.com/stonier/ecl_lite/issues</url>

--- a/ecl_converters_lite/package.xml
+++ b/ecl_converters_lite/package.xml
@@ -9,7 +9,7 @@
   </description>
   <author email="d.stonier@gmail.com">Daniel Stonier</author> -->
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_converters_lite</url>
   <url type="repository">https://github.com/stonier/ecl_lite</url>
   <url type="bugtracker">https://github.com/stonier/ecl_lite/issues</url>

--- a/ecl_errors/package.xml
+++ b/ecl_errors/package.xml
@@ -10,7 +10,7 @@
   </description>
   <author email="d.stonier@gmail.com">Daniel Stonier</author> -->
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_errors</url>
   <url type="repository">https://github.com/stonier/ecl_lite</url>
   <url type="bugtracker">https://github.com/stonier/ecl_lite/issues</url>

--- a/ecl_io/package.xml
+++ b/ecl_io/package.xml
@@ -9,7 +9,7 @@
   </description>
   <author email="d.stonier@gmail.com">Daniel Stonier</author> -->
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_io</url>
   <url type="repository">https://github.com/stonier/ecl_lite</url>
   <url type="bugtracker">https://github.com/stonier/ecl_lite/issues</url>

--- a/ecl_lite/package.xml
+++ b/ecl_lite/package.xml
@@ -7,7 +7,7 @@
   </description>
   <author email="d.stonier@gmail.com">Daniel Stonier</author>
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://www.ros.org/wiki/ecl_lite</url>
   <url type="repository">https://github.com/stonier/ecl_lite</url>
   <url type="bugtracker">https://github.com/stonier/ecl_lite/issues</url>

--- a/ecl_sigslots_lite/package.xml
+++ b/ecl_sigslots_lite/package.xml
@@ -9,7 +9,7 @@
   </description>
   <author email="d.stonier@gmail.com">Daniel Stonier</author> -->
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_sigslots_lite</url>
   <url type="repository">https://github.com/stonier/ecl_lite</url>
   <url type="bugtracker">https://github.com/stonier/ecl_lite/issues</url>

--- a/ecl_time_lite/package.xml
+++ b/ecl_time_lite/package.xml
@@ -8,7 +8,7 @@
   </description>
   <author email="d.stonier@gmail.com">Daniel Stonier</author> -->
   <maintainer email="d.stonier@gmail.com">Daniel Stonier</maintainer>
-  <license>BSD</license>
+  <license>BSD-3-Clause</license>
   <url type="website">http://wiki.ros.org/ecl_time_lite</url>
   <url type="repository">https://github.com/stonier/ecl_lite</url>
   <url type="bugtracker">https://github.com/stonier/ecl_lite/issues</url>


### PR DESCRIPTION
Updating the package.xml license tags to hold valid SPDX qualifiers. The rationale behind this is, that with
[meta-ros](https://github.com/ros/meta-ros) and
[superflore](https://github.com/ros-infrastructure/superflore) recipes get generated for the OpenEmbedded Linux build system. It will fetch the license tag and copy it over into the recipe. If no valid SPDX identifiers get found, it will issue an error, and a manual step to fix this is needed.

See the SPDX identifiers
[BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html)