### PR TITLE
[time_lite][io] Fix overloaded-virtual errors in noble/jazzy

### DIFF
--- a/ecl_io/include/ecl/io/sockets.hpp
+++ b/ecl_io/include/ecl/io/sockets.hpp
@@ -76,7 +76,7 @@ public:
   SocketError(const ErrorFlag& flag = UnknownError) : Error(flag)
   {}
   using Error::operator=;
- protected:
+protected:
   virtual const char* invalidArgErrorString() const
   { return "One of the arguments is invalid (usually a socket descriptor).";}
 #ifdef ECL_IS_WIN32

--- a/ecl_io/include/ecl/io/sockets.hpp
+++ b/ecl_io/include/ecl/io/sockets.hpp
@@ -75,7 +75,8 @@ public:
    */
   SocketError(const ErrorFlag& flag = UnknownError) : Error(flag)
   {}
-protected:
+  using Error::operator=;
+ protected:
   virtual const char* invalidArgErrorString() const
   { return "One of the arguments is invalid (usually a socket descriptor).";}
 #ifdef ECL_IS_WIN32

--- a/ecl_time_lite/include/ecl/time_lite/errors.hpp
+++ b/ecl_time_lite/include/ecl/time_lite/errors.hpp
@@ -40,6 +40,7 @@ public:
    */
   TimeError(const ErrorFlag& flag = UnknownError) : Error(flag) {}
 
+  using Error::operator=;
 protected:
   virtual const char* outOfRangeErrorString() const { return "The input time sec/nsec pair was outside of the permitted range."; }
   virtual const char* argNotSupportedErrorString() const { return "The clock specified is not supported on this system."; }


### PR DESCRIPTION
When building on ROS 2 Jazzy and Ubuntu Noble, I see a similar error as the one in the Build Farm ( https://build.ros2.org/job/Jbin_uN64__ecl_time_lite__ubuntu_noble_amd64__binary/197/console ):
```
23:07:46 /opt/ros/jazzy/include/ecl/errors/handlers.hpp:73:22: error: ‘virtual void ecl::Error::operator=(const ecl::ErrorFlag&)’ was hidden [-Werror=overloaded-virtual=]
23:07:46    73 |         virtual void operator=(const ErrorFlag &error) { error_flag = error; }
23:07:46       |                      ^~~~~~~~
23:07:46 /tmp/binarydeb/ros-jazzy-ecl-time-lite-1.2.0/src/lib/../../include/ecl/time_lite/errors.hpp:34:29: note:   by ‘ecl::TimeError::operator=’
23:07:46    34 | class ecl_time_lite_PUBLIC  TimeError : public Error {
23:07:46       |                             ^~~~~~~~~
23:07:46 cc1plus: all warnings being treated as errors
```

I presume the intention of the `operator=` in the base class is to use that implementation in the derived classes, so I have made that explicit through the `using` notation.

I have tested this on my Kobuki using a dockerfile and I have verified that it builds on Humble, Iron, and Jazzy. I can control my Kobuki using teleop_twist_keyboard. Dockerfile is here: https://github.com/ingotrobotics/turtlebot2_ros2/blob/feature/build_on_jazzy/turtlebot2_ros2.dockerfile

This is part of a series of small bug fixes to get the Turtlebot2 running in Jazzy.
- https://github.com/kobuki-base/kobuki_ros/pull/50